### PR TITLE
Fix routes for incentives and true market values

### DIFF
--- a/lib/definitions.js
+++ b/lib/definitions.js
@@ -721,7 +721,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/tmv/tmvservice/findcertifiedpriceforstyle"
+    "url": "/v1/api/tmv/tmvservice/findcertifiedpriceforstyle"
   },
   "getTmvPriceTypicallyEquippedUsedByStyleZip": {
     "params": {
@@ -744,7 +744,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/tmv/tmvservice/calculatetypicallyequippedusedtmv"
+    "url": "/v1/api/tmv/tmvservice/calculatetypicallyequippedusedtmv"
   },
   "getTmvPriceNewByStyleZip": {
     "params": {
@@ -767,7 +767,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/tmv/tmvservice/calculatenewtmv"
+    "url": "/v1/api/tmv/tmvservice/calculatenewtmv"
   },
   "getTmvPriceNewByMsrpVin": {
     "params": {
@@ -819,7 +819,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/tmv/tmvservice/calculateusedtmv"
+    "url": "/v1/api/tmv/tmvservice/calculateusedtmv"
   },
   "getIncentivesAndRebatesDetails": {
     "params": {
@@ -828,7 +828,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/incentive/incentiverepository/findbyid"
+    "url": "/v1/api/incentive/incentiverepository/findbyid"
   },
   "getIncentivesAndRebatesByMake": {
     "params": {
@@ -837,7 +837,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/incentive/incentiverepository/findincentivesbymakeid"
+    "url": "/v1/api/incentive/incentiverepository/findincentivesbymakeid"
   },
   "getIncentivesAndRebatesByMakeZip": {
     "params": {
@@ -850,7 +850,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/incentive/incentiverepository/findincentivesbymakeidandzipcode"
+    "url": "/v1/api/incentive/incentiverepository/findincentivesbymakeidandzipcode"
   },
   "getIncentivesAndRebatesByModelYearZip": {
     "params": {
@@ -863,7 +863,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/incentive/incentiverepository/findincentivesbymodelyearidandzipcode"
+    "url": "/v1/api/incentive/incentiverepository/findincentivesbymodelyearidandzipcode"
   },
   "getIncentivesAndRebatesByStyle": {
     "params": {
@@ -872,7 +872,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/incentive/incentiverepository/findincentivesbystyleid"
+    "url": "/v1/api/incentive/incentiverepository/findincentivesbystyleid"
   },
   "getIncentivesAndRebatesByStyleZip": {
     "params": {
@@ -885,7 +885,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/incentive/incentiverepository/findincentivesbystyleidandzipcode"
+    "url": "/v1/api/incentive/incentiverepository/findincentivesbystyleidandzipcode"
   },
   "getIncentivesAndRebatesByCategoryZip": {
     "params": {
@@ -898,7 +898,7 @@ module.exports = {
         "location": "querystring"
       }
     },
-    "url": "/v1/api/vehicle/incentive/incentiverepository/findincentivesbycategoryandzipcode"
+    "url": "/v1/api/incentive/incentiverepository/findincentivesbycategoryandzipcode"
   },
   "getMaintenanceActionDetails": {
     "params": {


### PR DESCRIPTION
http://developer.edmunds.com/api-documentation/vehicle/price_incentives_and_rebates/v1/07_findincentivesbystyleidandzipcode/api-description

The docs for incentives and true market values do have "vehicle" as part of the route but the url example given doesn't have it. Using the current routes as-is for these services 404s.
